### PR TITLE
feat(setQueryParameter): add refs to allow updater functions to have current value

### DIFF
--- a/src/useQueryParameter.ts
+++ b/src/useQueryParameter.ts
@@ -22,6 +22,7 @@ type UseQueryParameter = (
  */
 const useQueryParameter : UseQueryParameter = (name, defaultValue = '', mode = 'suppress') => {
   const [queryParameterValue, setState] = React.useState(defaultValue);
+  const previousParameterValueRef = React.useRef('');
 
   React.useEffect(() => {
     const url = new URL(window.location.href);
@@ -52,13 +53,15 @@ const useQueryParameter : UseQueryParameter = (name, defaultValue = '', mode = '
       // eslint-disable-next-line no-restricted-globals -- this is the intention of the library
       history.replaceState(null, '', url);
     }
+
+    previousParameterValueRef.current = queryParameterValue;
   }, [name, queryParameterValue]);
 
   const setQueryParameter = React.useCallback((nextVal:SetStateAction<string>) => {
     // Handle the setState api
     let normalizedNextVal = '';
     if (typeof nextVal === 'function') {
-      normalizedNextVal = nextVal(queryParameterValue);
+      normalizedNextVal = nextVal(previousParameterValueRef.current);
     } else {
       normalizedNextVal = nextVal;
     }
@@ -75,7 +78,7 @@ const useQueryParameter : UseQueryParameter = (name, defaultValue = '', mode = '
     }
 
     return normalizedNextVal;
-  }, [setState]);
+  }, [previousParameterValueRef, setState]);
 
   return [queryParameterValue, setQueryParameter];
 };

--- a/src/useQueryParameter.ts
+++ b/src/useQueryParameter.ts
@@ -55,7 +55,7 @@ const useQueryParameter : UseQueryParameter = (name, defaultValue = '', mode = '
     }
 
     previousParameterValueRef.current = queryParameterValue;
-  }, [name, queryParameterValue]);
+  }, [name, queryParameterValue, previousParameterValueRef]);
 
   const setQueryParameter = React.useCallback((nextVal:SetStateAction<string>) => {
     // Handle the setState api


### PR DESCRIPTION
Introduces a ref to maintain previousQueryValue in order to allow updater functions to be called within setQueryParameter with the correct latest value.

Reproduction code includes a comparison useState. Also uses a useEffect to verify that the set function doesn't bust the cache

```jsx
import { useEffect, useState } from 'react';
import useQueryParameter from '@mr-hooks/use-query-parameter';
import './App.css'

const App = () => {
  const [query, setQuery] = useQueryParameter('count', '5');
  const [state, setState] = useState(5);

  useEffect(() => {
    console.info('setState busted')
  }, [setState])

  useEffect(() => {
    console.info('setQuery busted')
  }, [setQuery])

  return (
    <div className="card">
    <button onClick={() => setQuery((count) => parseInt(count, 10) + 1)}>
        query is {query}
    </button>
    <button onClick={() => setState((count) => parseInt(count, 10) + 1)}>
        state is {state}
    </button>
    </div>
  )
}

export default App
```

<img width="998" alt="Screenshot 2023-07-31 at 00 01 23" src="https://github.com/mr-hooks/use-query-parameter/assets/9933592/0cfd6393-e93e-482e-a5c8-bd657e82ba0a">

Fixes: #11 

